### PR TITLE
fixed python 2 to 3 basestring issue

### DIFF
--- a/gspread_pandas/util.py
+++ b/gspread_pandas/util.py
@@ -3,6 +3,11 @@ from re import match
 import pandas as pd
 from gspread.utils import rowcol_to_a1, a1_to_rowcol
 
+try:
+    basestring
+except NameError:
+    basestring = str
+
 
 def parse_sheet_index(df, index):
     """Parse sheet index into df index"""


### PR DESCRIPTION
basestring does not exist in python 3 (I am running 3.6 and ran into this issue)

A little googling took me here:
https://stackoverflow.com/questions/34803467/unexpected-exception-name-basestring-is-not-defined-when-invoking-ansible2

This works in both python 2 and 3,

PS Thanks for this great library!