### PR TITLE
add code to map ValueInputOption to df columns

### DIFF
--- a/gspread_pandas/client.py
+++ b/gspread_pandas/client.py
@@ -562,9 +562,7 @@ class Spread:
             )
             yield start_cell, end_cell, val_chunks
 
-    def update_cells(
-        self, start, end, vals, sheet=None, raw_columns=[], input_option="USER_ENTERED"
-    ):
+    def update_cells(self, start, end, vals, sheet=None, raw_columns=[]):
         """Update the values in a given range. The values should be listed in order
         from left to right across rows.
 
@@ -615,6 +613,8 @@ class Spread:
                 ), "raw_columns must be a list of ints"
                 raw_cells = [i for i in cells if i.col in raw_columns]
                 self.sheet.update_cells(raw_cells, "RAW")
+            else:
+                raw_cells = []
 
             user_cells = [i for i in cells if i not in raw_cells]
             self.sheet.update_cells(user_cells, "USER_ENTERED")

--- a/gspread_pandas/client.py
+++ b/gspread_pandas/client.py
@@ -748,7 +748,7 @@ class Spread:
         start=(1, 1),
         replace=False,
         sheet=None,
-        raw_columns=[],
+        raw_column_names=[],
         freeze_index=False,
         freeze_headers=False,
         fill_value="",
@@ -775,7 +775,7 @@ class Spread:
             before saving,
             see :meth:`open_sheet <gspread_pandas.client.Spread.open_sheet>`
             (default None)
-        raw_columns : list, str
+        raw_column_names : list, str
             optional, list of columns from your dataframe that you want interpreted as RAW input in google sheets
         freeze_index : bool
             whether to freeze the index columns (default False)
@@ -829,9 +829,11 @@ class Spread:
             # make sure sheet is large enough
             self.sheet.resize(max(sheet_rows, req_rows), max(sheet_cols, req_cols))
 
-        if raw_columns != []:
+        if raw_column_names != []:
             mapped = map_cols_to_spread(start, end, df.columns.tolist())
-            raw_columns = [i[0] for i in mapped if i[1] in raw_columns]
+            raw_columns = [i[0] for i in mapped if i[1] in raw_column_names]
+        else:
+            raw_columns = []
 
         self.update_cells(
             start=start,

--- a/gspread_pandas/util.py
+++ b/gspread_pandas/util.py
@@ -213,6 +213,15 @@ def get_range(start, end):
     return "{0}:{1}".format(rowcol_to_a1(*start_int), rowcol_to_a1(*end_int))
 
 
+def map_cols_to_spread(start, end, cols):
+    """map df columns to spreadsheet columns"""
+    start_col = get_cell_as_tuple(start)[1]
+    end_col = get_cell_as_tuple(end)[1]
+    col_range = range(start_col, end_col + 1)
+    assert len(cols) == len(col_range), "df columns do not match spread columns"
+    return list(zip(col_range, cols))
+
+
 def create_merge_cells_request(sheet_id, start, end, merge_type="MERGE_ALL"):
     """
     Create v4 API request to merge rows and/or columns for a

--- a/gspread_pandas/util.py
+++ b/gspread_pandas/util.py
@@ -215,8 +215,8 @@ def get_range(start, end):
 
 def map_cols_to_spread(start, end, cols):
     """map df columns to spreadsheet columns"""
-    start_col = get_cell_as_tuple(start)[1]
-    end_col = get_cell_as_tuple(end)[1]
+    start_col = get_cell_as_tuple(start)[COL]
+    end_col = get_cell_as_tuple(end)[COL]
     col_range = range(start_col, end_col + 1)
     assert len(cols) == len(col_range), "df columns do not match spread columns"
     return list(zip(col_range, cols))


### PR DESCRIPTION
Hey @aiguofer - This is a naive implementation of the ValueInputOption by column functionality.

The simplest method I could find for doing this is splitting the existing `self.sheet.update_cells` logic AFTER the chunking occurs. This would double the number of API calls, but only if the new `raw_columns` parameter is set.

If `raw_columns` is set to not `[]` in `Spread.df_to_sheet`...

1. `self.df_to_sheet`maps the pandas columns to the integer column indexes they will populate in the google sheet
2. It passes a list of the mapped integer indexes to `self.update_cells` as the new `raw_columns` kwarg
3. For each update chunk, it will split out cells objects with `col` attributes that match an integer value from the `raw_columns` and run the gspread `update_cells` with the "RAW" kwarg instead

Let me know if you are good with this methodology, or if you have any suggested changes. I can clean it up, and test it out some more after.

Thanks!