### PR TITLE
Fix 100s retry

### DIFF
--- a/gspread_pandas/util.py
+++ b/gspread_pandas/util.py
@@ -287,14 +287,14 @@ def create_unmerge_cells_request(sheet_id, start, end):
 
 def monkey_patch_request(client, retry_delay=10):
     """Monkey patch gspread's Client.request to auto-retry with a delay when you get a
-    100s RESOURCE_EXCHAUSTED error."""
+    100 seconds RESOURCE_EXCHAUSTED error."""
 
     def request(*args, **kwargs):
         try:
             return ClientV4.request(client, *args, **kwargs)
         except APIError as e:
             error = str(e)
-            # Only retry on 100s quota breaches
+            # Only retry on 100 seconds quota breaches
             if "RESOURCE_EXHAUSTED" in error and "100" in error:
                 sleep(retry_delay)
                 return request(*args, **kwargs)

--- a/gspread_pandas/util.py
+++ b/gspread_pandas/util.py
@@ -295,7 +295,7 @@ def monkey_patch_request(client, retry_delay=10):
         except APIError as e:
             error = str(e)
             # Only retry on 100s quota breaches
-            if "RESOURCE_EXHAUSTED" in error and "100s" in error:
+            if "RESOURCE_EXHAUSTED" in error and "100" in error:
                 sleep(retry_delay)
                 return request(*args, **kwargs)
             else:


### PR DESCRIPTION
The google API change their error message for the `RESOURCE_EXHAUSTED`/100s error. 

This PR makes the check less specific, working both for the old and the new version of the error message.