### PR TITLE
Enable moving files to folder IDs as well as names

### DIFF
--- a/gspread_pandas/client.py
+++ b/gspread_pandas/client.py
@@ -384,7 +384,7 @@ class Client(ClientV4):
         self.refresh_directories()
         return parent
 
-    def move_file(self, file_id, path, create=False):
+    def move_file(self, file_id, path, id_string, create=False):
         """
         Move a file to the given path.
 
@@ -400,16 +400,20 @@ class Client(ClientV4):
         Returns
         -------
         """
-        if path == "/":
-            folder_id = "root"
+        if id_string:
+            folder_id = id_string
+        
         else:
-            parent, missing = folders_to_create(path, self._get_dirs(False))
-            if missing:
-                if not create:
-                    raise Exception("Folder does not exist")
+            if path == "/":
+                folder_id = "root"
+            else:
+                parent, missing = folders_to_create(path, self._get_dirs(False))
+                if missing:
+                    if not create:
+                        raise Exception("Folder does not exist")
 
-                parent = self.create_folder(path)
-            folder_id = parent["id"]
+                    parent = self.create_folder(path)
+                folder_id = parent["id"]
 
         old_parents = self._drive_request(
             "get", file_id, params={"fields": "parents"}

--- a/gspread_pandas/spread.py
+++ b/gspread_pandas/spread.py
@@ -1012,7 +1012,7 @@ class Spread:
         """
         return self.client.list_permissions(self.spread.id)
 
-    def move(self, path="/", create=True):
+    def move(self, path="/", id_string=None, create=True):
         """
         Move the current spreadsheet to the specified path in your Google drive. If the
         file is not currently in you drive, it will be added.
@@ -1027,4 +1027,4 @@ class Spread:
         Returns
         -------
         """
-        self.client.move_file(self.spread.id, path, create)
+        self.client.move_file(self.spread.id, path, id_string, create)


### PR DESCRIPTION
Simple change which fixed an issue I was having (and which is currently mentioned in issue #46 ) where a folder cannot be found by name when using the move command but whose ID can be located with the gspread_pandas client or by examining the URL. This enables moving a file to a folder (using either client.move_file() or spread.move()) using its id, rather than its name. This is done with the folder_id argument. When not explicitly using the folder_id argument, it behavies identically to previous behaviour.

This is my first time contributing to open source, please forgive any mistakes in the process. Hope this helps!