### PR TITLE
Get rid of requirement "past".

### DIFF
--- a/gspread_pandas/client.py
+++ b/gspread_pandas/client.py
@@ -10,7 +10,6 @@ from gspread.client import Client as ClientV4
 from gspread.exceptions import APIError, SpreadsheetNotFound
 from gspread.models import Spreadsheet
 from gspread.utils import finditem
-from past.builtins import basestring
 
 from gspread_pandas.conf import default_scope, get_creds
 from gspread_pandas.util import (
@@ -22,6 +21,12 @@ from gspread_pandas.util import (
 )
 
 __all__ = ["Client"]
+
+
+try:
+    basestring
+except NameError:
+    basestring = str
 
 
 class Client(ClientV4):

--- a/gspread_pandas/conf.py
+++ b/gspread_pandas/conf.py
@@ -6,7 +6,6 @@ from future.utils import reraise
 from google.oauth2.credentials import Credentials as OAuthCredentials
 from google.oauth2.service_account import Credentials as SACredentials
 from google_auth_oauthlib.flow import InstalledAppFlow
-from past.builtins import basestring
 
 from gspread_pandas.exceptions import ConfigException
 from gspread_pandas.util import decode
@@ -15,6 +14,12 @@ try:
     from pathlib import Path
 except ImportError:
     from pathlib2 import Path
+
+
+try:
+    basestring
+except NameError:
+    basestring = str
 
 
 __all__ = ["default_scope", "get_config", "get_creds"]

--- a/gspread_pandas/spread.py
+++ b/gspread_pandas/spread.py
@@ -13,7 +13,6 @@ from gspread.exceptions import (
 )
 from gspread.models import Worksheet
 from gspread.utils import fill_gaps, rightpad
-from past.builtins import basestring
 
 from gspread_pandas.client import Client
 from gspread_pandas.conf import default_scope
@@ -46,6 +45,12 @@ from gspread_pandas.util import (
 )
 
 __all__ = ["Spread"]
+
+
+try:
+    basestring
+except NameError:
+    basestring = str
 
 
 class Spread:

--- a/gspread_pandas/util.py
+++ b/gspread_pandas/util.py
@@ -10,8 +10,6 @@ from google.oauth2 import credentials as oauth2, service_account
 from gspread.client import Client as ClientV4
 from gspread.exceptions import APIError
 from gspread.utils import a1_to_rowcol, rowcol_to_a1
-from past.builtins import basestring
-
 from gspread_pandas.exceptions import MissMatchException
 
 ROW = START = 0
@@ -21,6 +19,12 @@ _WARNINGS_ALREADY_ENABLED = False
 
 # assuming no one will be 10 levels deep
 auto_generated_index_names = ["level_{}".format(i) for i in range(10)] + ["index"]
+
+
+try:
+    basestring
+except NameError:
+    basestring = str
 
 
 def decode(strg):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,4 +7,4 @@ include_trailing_comma = true
 force_grid_wrap = 0
 combine_as_imports = true
 line_length = 88
-known_third_party = ["Crypto", "betamax", "betamax_serializers", "future", "google", "google_auth_oauthlib", "gspread", "numpy", "oauth2client", "pandas", "past", "pytest", "requests", "setuptools"]
+known_third_party = ["Crypto", "betamax", "betamax_serializers", "future", "google", "google_auth_oauthlib", "gspread", "numpy", "oauth2client", "pandas", "pytest", "requests", "setuptools"]

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -1,7 +1,12 @@
 import pytest
-from past.builtins import basestring
 
 from gspread_pandas import Client
+
+
+try:
+    basestring
+except NameError:
+    basestring = str
 
 
 @pytest.mark.usefixtures("betamax_client")


### PR DESCRIPTION
The requirement `past` is quite old requirement. The last release is from seven years ago and Python3.8 is giving deprecation warning from importing `imp`. So how about just getting rid of the whole requirement?

I was only able to do minor testing, sorry for that.