### PR TITLE
fix versions of gspread minor to 5.0.0 in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Reqs
-gspread>=3.0.0
+gspread<5.0.0
 pandas>=0.20.0
 decorator
 six


### PR DESCRIPTION
This is due the new gspread version 5.0.0 split models module and then it breaks on the imports.

Closes #59 