### PR TITLE
fix key name of gridProperties while fetching frozen column from sheet

### DIFF
--- a/gspread_pandas/spread.py
+++ b/gspread_pandas/spread.py
@@ -590,7 +590,7 @@ class Spread:
             "frozenRowCount", 0
         )
         frozen_cols = self._sheet_metadata["properties"]["gridProperties"].get(
-            "frozenColCount", 0
+            "frozenColumnCount", 0
         )
 
         row_resize = max(rows, frozen_rows + 1)


### PR DESCRIPTION
`clear_sheet` doesn't work on current version if the sheet has frozen column as frozen column count returns default_value(0) for any sheet due to the name mismatch in gridproperties and that throws `APIError.`
This pr fixes the mismatched name.

Following are the key from gridProperties.
```
self._sheet_metadata["properties"]["gridProperties"].keys()
```
returns
```
dict_keys(['rowCount', 'columnCount', 'frozenRowCount', 'frozenColumnCount'])
```