### PR TITLE
removing old redundant code that yields SettingWithCopyWarning, remove depracated inplace, and fix hanging tests

### DIFF
--- a/gspread_pandas/util.py
+++ b/gspread_pandas/util.py
@@ -1,5 +1,4 @@
 import warnings
-from distutils.version import StrictVersion
 from re import match
 from time import sleep
 
@@ -217,13 +216,7 @@ def fillna(df, fill_value=""):
     """
     for col in df.dtypes[df.dtypes == "category"].index:
         if fill_value not in df[col].cat.categories:
-            df[col].cat.add_categories([fill_value], inplace=True)
-    # Known bug https://github.com/pandas-dev/pandas/issues/25472
-    if StrictVersion(pd.__version__) >= StrictVersion("1.0"):
-        for col in df.dtypes[
-            df.dtypes.apply(lambda x: x in ["float64", "int16"])
-        ].index:
-            df[col] = df[col].astype("float")
+            df[col] = df[col].cat.add_categories([fill_value])
     return df.fillna(fill_value)
 
 

--- a/tests/conf_test.py
+++ b/tests/conf_test.py
@@ -45,7 +45,7 @@ class Test_get_creds:
             conf.get_creds(user=None)
 
     def test_oauth_first_time(self, mocker, set_oauth_config, creds_json):
-        mocked = mocker.patch.object(conf.InstalledAppFlow, "run_console")
+        mocked = mocker.patch.object(conf.InstalledAppFlow, "run_local_server")
         mocked.return_value = OAuth2Credentials.from_authorized_user_info(creds_json)
         conf.get_creds()
         # python 3.5 doesn't have assert_called_once
@@ -53,10 +53,10 @@ class Test_get_creds:
         assert (conf.get_config_dir() / "creds" / "default").exists()
 
     def test_oauth_first_time_no_save(self, mocker, set_oauth_config):
-        mocker.patch.object(conf.InstalledAppFlow, "run_console")
+        mocker.patch.object(conf.InstalledAppFlow, "run_local_server")
         conf.get_creds(save=False)
         # python 3.5 doesn't have assert_called_once
-        assert conf.InstalledAppFlow.run_console.call_count == 1
+        assert conf.InstalledAppFlow.run_local_server.call_count == 1
 
     def test_oauth_default(self, make_creds):
         assert isinstance(conf.get_creds(), OAuth2Credentials)


### PR DESCRIPTION
[This](https://github.com/aiguofer/gspread-pandas/blob/da38bc4adfcc91d092715a88fb36f8e1963a756d/gspread_pandas/util.py#L221) hack, which was created due to the bug during that time, has now been fixed. So i am assuming it is better to remove it rather than fixing code(`util.py:226`) that is giving `SettingWithCopyWarning`. Also, `inplace` parameter in pandas.Categorical.add_categories is deprecated and thus removed.
Also, some fix on tests !