### PR TITLE
work-around for https://github.com/aiguofer/gspread-pandas/issues/100

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Reqs
-gspread>=5.0.0
+gspread>=5.0.0, <6
 pandas>=0.20.0
 decorator
 google-auth


### PR DESCRIPTION
Until gspread-pandas is upgraded to the new auth API, let's limit the required gspread version.